### PR TITLE
GH does not send repositories in installation:deleted webhooks

### DIFF
--- a/octohook/events.py
+++ b/octohook/events.py
@@ -199,7 +199,7 @@ class InstallationEvent(__WebhookEvent):
         self.installation = Installation(payload.get("installation"))
 
         self.repositories = [
-            ShortRepository(repo) for repo in payload.get("repositories", list())
+            ShortRepository(repo) for repo in payload.get("repositories", [])
         ]
 
 

--- a/octohook/events.py
+++ b/octohook/events.py
@@ -199,7 +199,7 @@ class InstallationEvent(__WebhookEvent):
         self.installation = Installation(payload.get("installation"))
 
         self.repositories = [
-            ShortRepository(repo) for repo in payload.get("repositories")
+            ShortRepository(repo) for repo in payload.get("repositories", list())
         ]
 
 


### PR DESCRIPTION
Today I've encountered this issue - and it seems that Github is not sending repositories in webhook which is triggered by uninstalling app.